### PR TITLE
6107: Upgraded os2forms core requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ about writing changes to this log.
 
 ## [Unreleased]
 
-## [1.2.0] 2025-12-08
+## [1.2.0] 2025-12-11
 
 * Allowed `os2forms/os2forms` `5.x`.
 * Disallowed `os2forms/os2forms` `3.x`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+## [1.2.0] 2025-12-08
+
+* Allowed `os2forms/os2forms` `5.x`.
+* Disallowed `os2forms/os2forms` `3.x`.
+
 ## [1.1.1] 2025-03-12
 
 - Allowed `os2forms/os2forms` 4.0.
@@ -22,7 +27,8 @@ about writing changes to this log.
 
 - Initial version
 
-[Unreleased]: https://github.com/itk-dev/os2forms_user_field_lookup/compare/1.1.1...HEAD
+[Unreleased]: https://github.com/itk-dev/os2forms_user_field_lookup/compare/1.2.0...HEAD
+[1.2.0]: https://github.com/itk-dev/os2forms_user_field_lookup/compare/1.1.1...1.2.0
 [1.1.1]: https://github.com/itk-dev/os2forms_user_field_lookup/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/itk-dev/os2forms_user_field_lookup/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/itk-dev/os2forms_user_field_lookup/releases/tag/1.0.0

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "os2forms/os2forms": "^3.13 || ^4.0"
+        "os2forms/os2forms": "^4.0 || ^5.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/6107

#### Description

* Allow `os2forms`-core `5.x`
* Disallow `os2forms`-core `3.x`


> [!CAUTION]
> The current set of package requirements cannot be installed from scratch. An issue discussing this has been [created](https://github.com/OS2Forms/os2forms/issues/244). We fully expect this to work in already installed installations, hence we ignore failed GitHub Actions right at this moment.
